### PR TITLE
Update dependency versions

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"   % "2.5.2")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage"  % "2.0.11")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"     % "5.10.0")
-addSbtPlugin("com.github.sbt"    % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.5.2")
+addSbtPlugin("org.scoverage"  % "sbt-scoverage"  % "2.0.11")
+addSbtPlugin("com.github.sbt" % "sbt-header"     % "5.11.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")


### PR DESCRIPTION
Update versions of sbt-header and sbt-ci-release:

sbt-header has been moved to new groupId - https://github.com/sbt/sbt-header/releases/tag/v5.11.0
sbt-ci-release 1.5.12 is no longer available in maven repos, updating to latest - https://central.sonatype.com/artifact/com.github.sbt/sbt-ci-release_2.12_1.0/versions
